### PR TITLE
Python setup: Make pytetrad installable via pip and the java functions importable

### DIFF
--- a/pytetrad/Images.py
+++ b/pytetrad/Images.py
@@ -7,7 +7,7 @@ BASE_DIR = ".."
 sys.path.append(BASE_DIR)
 jpype.startJVM(classpath=[f"{BASE_DIR}/pytetrad/resources/tetrad-current.jar"])
 
-import tools.translate as tr
+import pytetrad.tools.translate as tr
 import edu.cmu.tetrad.algcomparison.algorithm.multi as multi
 import edu.cmu.tetrad.util as util
 import java.util as jutil

--- a/pytetrad/Images.py
+++ b/pytetrad/Images.py
@@ -3,9 +3,9 @@ import sys
 import jpype.imports
 import pandas as pd
 
-BASE_DIR = ".."
-sys.path.append(BASE_DIR)
-jpype.startJVM(classpath=[f"{BASE_DIR}/pytetrad/resources/tetrad-current.jar"])
+# BASE_DIR = ".."
+# sys.path.append(BASE_DIR)
+jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
 
 import pytetrad.tools.translate as tr
 import edu.cmu.tetrad.algcomparison.algorithm.multi as multi

--- a/pytetrad/Images.py
+++ b/pytetrad/Images.py
@@ -3,10 +3,10 @@ import sys
 import jpype.imports
 import pandas as pd
 
-# BASE_DIR = ".."
-# sys.path.append(BASE_DIR)
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/Images.py
+++ b/pytetrad/Images.py
@@ -5,7 +5,14 @@ import pandas as pd
 
 # BASE_DIR = ".."
 # sys.path.append(BASE_DIR)
-jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pytetrad.tools.translate as tr
 import edu.cmu.tetrad.algcomparison.algorithm.multi as multi

--- a/pytetrad/Images.py
+++ b/pytetrad/Images.py
@@ -3,13 +3,12 @@ import sys
 import jpype.imports
 import pandas as pd
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/algcomparison_fci_algs.py
+++ b/pytetrad/algcomparison_fci_algs.py
@@ -4,13 +4,12 @@
 
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/algcomparison_fci_algs.py
+++ b/pytetrad/algcomparison_fci_algs.py
@@ -5,7 +5,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/algcomparison_fci_algs.py
+++ b/pytetrad/algcomparison_fci_algs.py
@@ -4,10 +4,14 @@
 
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 from edu.cmu.tetrad.util import Params, Parameters
 

--- a/pytetrad/algcomparison_large_fges.py
+++ b/pytetrad/algcomparison_large_fges.py
@@ -4,13 +4,12 @@
 
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/algcomparison_large_fges.py
+++ b/pytetrad/algcomparison_large_fges.py
@@ -4,11 +4,14 @@
 
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-    # jpype.startJVM("-Xmx40g", classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 from edu.cmu.tetrad.util import Params, Parameters
 

--- a/pytetrad/algcomparison_large_fges.py
+++ b/pytetrad/algcomparison_large_fges.py
@@ -5,7 +5,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/compare_projects_fci.py
+++ b/pytetrad/compare_projects_fci.py
@@ -7,7 +7,7 @@ except OSError:
 
 import pandas as pd
 import numpy as np
-import tools.translate as tr
+import pytetrad.tools.translate as tr
 
 import edu.cmu.tetrad.search as ts
 import edu.cmu.tetrad.search.test as test

--- a/pytetrad/compare_projects_fci.py
+++ b/pytetrad/compare_projects_fci.py
@@ -1,9 +1,13 @@
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 import numpy as np

--- a/pytetrad/compare_projects_fci.py
+++ b/pytetrad/compare_projects_fci.py
@@ -1,7 +1,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/compare_projects_fci.py
+++ b/pytetrad/compare_projects_fci.py
@@ -1,12 +1,11 @@
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/compare_projects_ges.py
+++ b/pytetrad/compare_projects_ges.py
@@ -5,10 +5,14 @@ import time
 import jpype.imports
 from causallearn.search.ScoreBased.GES import ges
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pytetrad.tools.translate as tr
 import pytetrad.tools.simulate as sim

--- a/pytetrad/compare_projects_ges.py
+++ b/pytetrad/compare_projects_ges.py
@@ -5,13 +5,12 @@ import time
 import jpype.imports
 from causallearn.search.ScoreBased.GES import ges
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/compare_projects_ges.py
+++ b/pytetrad/compare_projects_ges.py
@@ -10,8 +10,8 @@ try:
 except OSError:
     print("JVM already started")
 
-import tools.translate as tr
-import tools.simulate as sim
+import pytetrad.tools.translate as tr
+import pytetrad.tools.simulate as sim
 
 import edu.cmu.tetrad.search as ts
 import edu.cmu.tetrad.search.score as score

--- a/pytetrad/compare_projects_ges.py
+++ b/pytetrad/compare_projects_ges.py
@@ -6,7 +6,9 @@ import jpype.imports
 from causallearn.search.ScoreBased.GES import ges
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/compare_projects_pc.py
+++ b/pytetrad/compare_projects_pc.py
@@ -7,7 +7,7 @@ except OSError:
 
 import pandas as pd
 import numpy as np
-import tools.translate as tr
+import pytetrad.tools.translate as tr
 
 import edu.cmu.tetrad.search as ts
 import edu.cmu.tetrad.search.test as test

--- a/pytetrad/compare_projects_pc.py
+++ b/pytetrad/compare_projects_pc.py
@@ -1,9 +1,13 @@
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 import numpy as np

--- a/pytetrad/compare_projects_pc.py
+++ b/pytetrad/compare_projects_pc.py
@@ -1,7 +1,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/compare_projects_pc.py
+++ b/pytetrad/compare_projects_pc.py
@@ -1,12 +1,11 @@
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/convert_datasets.py
+++ b/pytetrad/convert_datasets.py
@@ -1,9 +1,13 @@
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 import pytetrad.tools.translate as tr

--- a/pytetrad/convert_datasets.py
+++ b/pytetrad/convert_datasets.py
@@ -1,7 +1,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/convert_datasets.py
+++ b/pytetrad/convert_datasets.py
@@ -6,7 +6,7 @@ except OSError:
     print("JVM already started")
 
 import pandas as pd
-import tools.translate as tr
+import pytetrad.tools.translate as tr
 
 df = pd.read_csv(f"resources/airfoil-self-noise.continuous.txt", sep="\t")
 df = df.astype({col: "float64" for col in df.columns})

--- a/pytetrad/convert_datasets.py
+++ b/pytetrad/convert_datasets.py
@@ -1,12 +1,11 @@
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/general_scoring_example.py
+++ b/pytetrad/general_scoring_example.py
@@ -3,7 +3,9 @@ from jpype import JImplements, JOverride
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/general_scoring_example.py
+++ b/pytetrad/general_scoring_example.py
@@ -9,7 +9,7 @@ except OSError:
 
 import pandas as pd
 
-import tools.translate as tr
+import pytetrad.tools.translate as tr
 
 import java.util as util
 import edu.cmu.tetrad.data as td

--- a/pytetrad/general_scoring_example.py
+++ b/pytetrad/general_scoring_example.py
@@ -2,13 +2,12 @@
 from jpype import JImplements, JOverride
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/general_scoring_example.py
+++ b/pytetrad/general_scoring_example.py
@@ -2,10 +2,14 @@
 from jpype import JImplements, JOverride
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 

--- a/pytetrad/jpype_example.py
+++ b/pytetrad/jpype_example.py
@@ -4,10 +4,14 @@ import sys
 import jpype.imports
 import pandas as pd
 
-# BASE_DIR = "/Users/bryanandrews/Documents/py-tetrad"
-BASE_DIR = ".."
-sys.path.append(BASE_DIR)
-jpype.startJVM(classpath=[f"{BASE_DIR}/pytetrad/resources/tetrad-current.jar"])
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pytetrad.tools.translate as tr
 import pytetrad.tools.translate as ptt

--- a/pytetrad/jpype_example.py
+++ b/pytetrad/jpype_example.py
@@ -4,13 +4,12 @@ import sys
 import jpype.imports
 import pandas as pd
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/jpype_example.py
+++ b/pytetrad/jpype_example.py
@@ -5,7 +5,9 @@ import jpype.imports
 import pandas as pd
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/jpype_example.py
+++ b/pytetrad/jpype_example.py
@@ -9,9 +9,9 @@ BASE_DIR = ".."
 sys.path.append(BASE_DIR)
 jpype.startJVM(classpath=[f"{BASE_DIR}/pytetrad/resources/tetrad-current.jar"])
 
-import tools.translate as tr
-import tools.translate as ptt
-import tools.visualize as ptv
+import pytetrad.tools.translate as tr
+import pytetrad.tools.translate as ptt
+import pytetrad.tools.visualize as ptv
 import edu.cmu.tetrad.graph as tg
 import edu.cmu.tetrad.search as ts
 import edu.cmu.tetrad.data as td

--- a/pytetrad/proxy_testing.py
+++ b/pytetrad/proxy_testing.py
@@ -10,7 +10,7 @@ except OSError:
 import pandas as pd
 import numpy as np
 
-import tools.translate as tr
+import pytetrad.tools.translate as tr
 
 import java.util as util
 import edu.cmu.tetrad.data as td

--- a/pytetrad/proxy_testing.py
+++ b/pytetrad/proxy_testing.py
@@ -3,7 +3,9 @@ from jpype import JImplements, JOverride
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/proxy_testing.py
+++ b/pytetrad/proxy_testing.py
@@ -2,13 +2,12 @@
 from jpype import JImplements, JOverride
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/proxy_testing.py
+++ b/pytetrad/proxy_testing.py
@@ -2,10 +2,14 @@
 from jpype import JImplements, JOverride
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 import numpy as np

--- a/pytetrad/render_gdot.py
+++ b/pytetrad/render_gdot.py
@@ -8,8 +8,8 @@ except OSError:
 import pandas as pd
 import graphviz as gviz
 
-import tools.TetradSearch as search
-import tools.translate as tr
+import pytetrad.tools.TetradSearch as search
+import pytetrad.tools.translate as tr
 
 data = pd.read_csv("resources/airfoil-self-noise.continuous.txt", sep="\t")
 data = data.astype({col: "float64" for col in data.columns})

--- a/pytetrad/render_gdot.py
+++ b/pytetrad/render_gdot.py
@@ -1,7 +1,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/render_gdot.py
+++ b/pytetrad/render_gdot.py
@@ -1,9 +1,13 @@
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 import graphviz as gviz

--- a/pytetrad/render_gdot.py
+++ b/pytetrad/render_gdot.py
@@ -1,12 +1,11 @@
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/run_TetradSearch.py
+++ b/pytetrad/run_TetradSearch.py
@@ -1,7 +1,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/run_TetradSearch.py
+++ b/pytetrad/run_TetradSearch.py
@@ -6,7 +6,7 @@ except OSError:
     pass
 
 import pandas as pd
-import tools.TetradSearch as ts
+import pytetrad.tools.TetradSearch as ts
 
 df = pd.read_csv("resources/airfoil-self-noise.continuous.txt", sep="\t")
 df = df.astype({col: "float64" for col in df.columns})

--- a/pytetrad/run_TetradSearch.py
+++ b/pytetrad/run_TetradSearch.py
@@ -1,9 +1,13 @@
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    pass
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 import pytetrad.tools.TetradSearch as ts

--- a/pytetrad/run_TetradSearch.py
+++ b/pytetrad/run_TetradSearch.py
@@ -1,12 +1,11 @@
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/run_continuous.py
+++ b/pytetrad/run_continuous.py
@@ -7,7 +7,7 @@ except OSError:
 
 import pandas as pd
 
-import tools.TetradSearch as ts
+import pytetrad.tools.TetradSearch as ts
 
 data = pd.read_csv("resources/airfoil-self-noise.continuous.txt", sep="\t")
 # data = pd.read_csv("resources/sample_lng_data_10_2_1000.txt", sep="\t")

--- a/pytetrad/run_continuous.py
+++ b/pytetrad/run_continuous.py
@@ -1,7 +1,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/run_continuous.py
+++ b/pytetrad/run_continuous.py
@@ -1,9 +1,13 @@
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 

--- a/pytetrad/run_continuous.py
+++ b/pytetrad/run_continuous.py
@@ -1,12 +1,11 @@
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/run_discrete.py
+++ b/pytetrad/run_discrete.py
@@ -7,7 +7,7 @@ except OSError:
 
 import pandas as pd
 
-import tools.TetradSearch as ts
+import pytetrad.tools.TetradSearch as ts
 
 data = pd.read_csv("resources/bridges.data.version211_rev.txt", sep="\t")
 

--- a/pytetrad/run_discrete.py
+++ b/pytetrad/run_discrete.py
@@ -1,7 +1,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/run_discrete.py
+++ b/pytetrad/run_discrete.py
@@ -1,9 +1,13 @@
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 

--- a/pytetrad/run_discrete.py
+++ b/pytetrad/run_discrete.py
@@ -1,12 +1,11 @@
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/run_general_pc_various_ways.py
+++ b/pytetrad/run_general_pc_various_ways.py
@@ -6,7 +6,9 @@ import time
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/run_general_pc_various_ways.py
+++ b/pytetrad/run_general_pc_various_ways.py
@@ -5,10 +5,14 @@ import time
 
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 

--- a/pytetrad/run_general_pc_various_ways.py
+++ b/pytetrad/run_general_pc_various_ways.py
@@ -5,13 +5,12 @@ import time
 
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/run_general_pc_various_ways.py
+++ b/pytetrad/run_general_pc_various_ways.py
@@ -12,11 +12,11 @@ except OSError:
 
 import pandas as pd
 
-import tools.translate as tr
+import pytetrad.tools.translate as tr
 
 import edu.cmu.tetrad.search as ts
 import edu.cmu.tetrad.search.test as tt
-from tools import WrappedClKci as wc
+from pytetrad.tools import WrappedClKci as wc
 
 try:
     from causallearn.utils.cit import CIT

--- a/pytetrad/run_markov_checker.py
+++ b/pytetrad/run_markov_checker.py
@@ -7,7 +7,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/run_markov_checker.py
+++ b/pytetrad/run_markov_checker.py
@@ -6,10 +6,14 @@
 
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 import pytetrad.tools.TetradSearch as search

--- a/pytetrad/run_markov_checker.py
+++ b/pytetrad/run_markov_checker.py
@@ -12,8 +12,8 @@ except OSError:
     print("JVM already started")
 
 import pandas as pd
-import tools.TetradSearch as search
-# from tools import WrappedClKci as wc
+import pytetrad.tools.TetradSearch as search
+# from pytetrad.tools import WrappedClKci as wc
 
 # data = pd.read_csv("resources/airfoil-self-noise.continuous.txt", sep="\t")
 data = pd.read_csv("resources/sample_lng_data_10_2_1000.txt", sep="\t")

--- a/pytetrad/run_markov_checker.py
+++ b/pytetrad/run_markov_checker.py
@@ -6,13 +6,12 @@
 
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/run_mixed.py
+++ b/pytetrad/run_mixed.py
@@ -7,7 +7,7 @@ except OSError:
 
 import pandas as pd
 
-import tools.TetradSearch as search
+import pytetrad.tools.TetradSearch as search
 
 data = pd.read_csv("resources/auto-mpg.data.mixed.max.3.categories.txt", sep="\t")
 data = data.astype({col: "float64" for col in data.columns if col != "origin"})

--- a/pytetrad/run_mixed.py
+++ b/pytetrad/run_mixed.py
@@ -1,7 +1,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/run_mixed.py
+++ b/pytetrad/run_mixed.py
@@ -1,9 +1,13 @@
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 

--- a/pytetrad/run_mixed.py
+++ b/pytetrad/run_mixed.py
@@ -1,12 +1,11 @@
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/run_with_bootstrapping.py
+++ b/pytetrad/run_with_bootstrapping.py
@@ -4,7 +4,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/run_with_bootstrapping.py
+++ b/pytetrad/run_with_bootstrapping.py
@@ -3,10 +3,14 @@
 
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pandas as pd
 

--- a/pytetrad/run_with_bootstrapping.py
+++ b/pytetrad/run_with_bootstrapping.py
@@ -13,7 +13,7 @@ import pandas as pd
 data = pd.read_csv("resources/airfoil-self-noise.continuous.txt", sep="\t")
 data = data.astype({col: "float64" for col in data.columns})
 
-import tools.TetradSearch as search
+import pytetrad.tools.TetradSearch as search
 
 search = search.TetradSearch(data)
 search.use_sem_bic(penalty_discount=2)

--- a/pytetrad/run_with_bootstrapping.py
+++ b/pytetrad/run_with_bootstrapping.py
@@ -3,13 +3,12 @@
 
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/simulate_continuous.py
+++ b/pytetrad/simulate_continuous.py
@@ -2,7 +2,9 @@ import jpype
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/simulate_continuous.py
+++ b/pytetrad/simulate_continuous.py
@@ -1,13 +1,12 @@
 import jpype
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/simulate_continuous.py
+++ b/pytetrad/simulate_continuous.py
@@ -6,8 +6,8 @@ try:
 except OSError:
     print("JVM already started")
 
-import tools.translate as tr
-import tools.simulate as sim
+import pytetrad.tools.translate as tr
+import pytetrad.tools.simulate as sim
 
 D, G = sim.simulateContinuous(num_meas=100, samp_size=1000)
 

--- a/pytetrad/simulate_continuous.py
+++ b/pytetrad/simulate_continuous.py
@@ -1,10 +1,14 @@
 import jpype
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pytetrad.tools.translate as tr
 import pytetrad.tools.simulate as sim

--- a/pytetrad/simulate_discrete.py
+++ b/pytetrad/simulate_discrete.py
@@ -1,9 +1,13 @@
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pytetrad.tools.translate as tr
 import pytetrad.tools.simulate as sim

--- a/pytetrad/simulate_discrete.py
+++ b/pytetrad/simulate_discrete.py
@@ -1,7 +1,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/simulate_discrete.py
+++ b/pytetrad/simulate_discrete.py
@@ -5,8 +5,8 @@ try:
 except OSError:
     print("JVM already started")
 
-import tools.translate as tr
-import tools.simulate as sim
+import pytetrad.tools.translate as tr
+import pytetrad.tools.simulate as sim
 
 D, G = sim.simulateDiscrete(num_meas=100, samp_size=1000)
 

--- a/pytetrad/simulate_discrete.py
+++ b/pytetrad/simulate_discrete.py
@@ -1,12 +1,11 @@
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/simulate_lee_hastie.py
+++ b/pytetrad/simulate_lee_hastie.py
@@ -5,8 +5,8 @@ try:
 except OSError:
     print("JVM already started")
 
-import tools.translate as tr
-import tools.simulate as sim
+import pytetrad.tools.translate as tr
+import pytetrad.tools.simulate as sim
 
 ## Simulates data with both continuous and discrete columns.
 D, G = sim.simulateLeeHastie(num_meas=100, samp_size=1000)

--- a/pytetrad/simulate_lee_hastie.py
+++ b/pytetrad/simulate_lee_hastie.py
@@ -1,9 +1,13 @@
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pytetrad.tools.translate as tr
 import pytetrad.tools.simulate as sim

--- a/pytetrad/simulate_lee_hastie.py
+++ b/pytetrad/simulate_lee_hastie.py
@@ -1,7 +1,9 @@
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/simulate_lee_hastie.py
+++ b/pytetrad/simulate_lee_hastie.py
@@ -1,12 +1,11 @@
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/tools/TetradSearch.py
+++ b/pytetrad/tools/TetradSearch.py
@@ -9,11 +9,14 @@ import jpype.imports
 
 # print('cwd = ', os.getcwd())
 
-try:
-    jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[f"../resources/tetrad-current.jar"])
-except OSError:
-    print("can't load jvm")
-    pass
+import os
+jar_path = os.path.abspath("../resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import pytetrad.tools.translate as tr
 import edu.cmu.tetrad.search as ts

--- a/pytetrad/tools/TetradSearch.py
+++ b/pytetrad/tools/TetradSearch.py
@@ -9,13 +9,12 @@ import jpype.imports
 
 # print('cwd = ', os.getcwd())
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/tools/TetradSearch.py
+++ b/pytetrad/tools/TetradSearch.py
@@ -7,10 +7,10 @@ import os
 
 import jpype.imports
 
-print('cwd = ', os.getcwd())
+# print('cwd = ', os.getcwd())
 
 try:
-    jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[f"resources/tetrad-current.jar"])
+    jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[f"../resources/tetrad-current.jar"])
 except OSError:
     print("can't load jvm")
     pass

--- a/pytetrad/tools/TetradSearch.py
+++ b/pytetrad/tools/TetradSearch.py
@@ -10,7 +10,9 @@ import jpype.imports
 # print('cwd = ', os.getcwd())
 
 import os
-jar_path = os.path.abspath("../resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/tools/TetradSearch.py
+++ b/pytetrad/tools/TetradSearch.py
@@ -15,7 +15,7 @@ except OSError:
     print("can't load jvm")
     pass
 
-import tools.translate as tr
+import pytetrad.tools.translate as tr
 import edu.cmu.tetrad.search as ts
 import edu.cmu.tetrad.data as td
 import edu.cmu.tetrad.graph as gr

--- a/pytetrad/tools/WrappedClKci.py
+++ b/pytetrad/tools/WrappedClKci.py
@@ -18,10 +18,14 @@
 import jpype.imports
 from jpype import JImplements, JOverride
 
-try:
-    jpype.startJVM(classpath=[f"../resources/tetrad-current.jar"])
-except OSError:
-    print("JVM already started")
+import os
+jar_path = os.path.abspath("../resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 try:
     from causallearn.utils.cit import CIT

--- a/pytetrad/tools/WrappedClKci.py
+++ b/pytetrad/tools/WrappedClKci.py
@@ -19,7 +19,9 @@ import jpype.imports
 from jpype import JImplements, JOverride
 
 import os
-jar_path = os.path.abspath("../resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/tools/WrappedClKci.py
+++ b/pytetrad/tools/WrappedClKci.py
@@ -18,13 +18,12 @@
 import jpype.imports
 from jpype import JImplements, JOverride
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/tools/WrappedClKci.py
+++ b/pytetrad/tools/WrappedClKci.py
@@ -19,7 +19,7 @@ import jpype.imports
 from jpype import JImplements, JOverride
 
 try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
+    jpype.startJVM(classpath=[f"../resources/tetrad-current.jar"])
 except OSError:
     print("JVM already started")
 

--- a/pytetrad/tools/WrappedClKci.py
+++ b/pytetrad/tools/WrappedClKci.py
@@ -6,7 +6,7 @@
 # instructions.)
 #
 # To use WrappedClKci as a test in py-tetrad, you can do the following:
-# import tools/WrappedClKci as wc
+# import pytetrad.tools/WrappedClKci as wc
 # ... load data into a pandas DataFrame df ...
 # test = wc.WrappedClKci(df, alpha=0.01)
 #
@@ -30,7 +30,7 @@ try:
 except ImportError as e:
     print('Could not import a causal-learn module: ', e)
 
-import tools.translate as tr
+import pytetrad.tools.translate as tr
 import edu.cmu.tetrad.data as td
 import edu.cmu.tetrad.graph as tg
 import edu.cmu.tetrad.search as ts

--- a/pytetrad/tools/simulate.py
+++ b/pytetrad/tools/simulate.py
@@ -6,7 +6,7 @@ import jpype
 import jpype.imports
 
 try:
-   jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
+   jpype.startJVM(classpath=[f"../resources/tetrad-current.jar"])
 except OSError:
     pass
 

--- a/pytetrad/tools/simulate.py
+++ b/pytetrad/tools/simulate.py
@@ -5,10 +5,14 @@
 import jpype
 import jpype.imports
 
-try:
-   jpype.startJVM(classpath=[f"../resources/tetrad-current.jar"])
-except OSError:
-    pass
+import os
+jar_path = os.path.abspath("../resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 ## Some functions wrapping various classes in Tetrad. Feel free to just steal
 ## the relevant code for your own projects, or 'pip install' this Github directory

--- a/pytetrad/tools/simulate.py
+++ b/pytetrad/tools/simulate.py
@@ -6,7 +6,9 @@ import jpype
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("../resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/tools/simulate.py
+++ b/pytetrad/tools/simulate.py
@@ -5,13 +5,12 @@
 import jpype
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/pytetrad/tools/translate.py
+++ b/pytetrad/tools/translate.py
@@ -6,7 +6,7 @@ import jpype
 import jpype.imports
 
 try:
-    jpype.startJVM(classpath=[f"resources/tetrad-current.jar"])
+    jpype.startJVM(classpath=[f"../resources/tetrad-current.jar"])
 except OSError:
     pass
 
@@ -18,9 +18,9 @@ import sys
 ## and call these functions. will add more named parameters to help one see which 
 ## methods for the the searches can be controlled.
 
-# this needs to happen before import pytetrad (otherwise lib cant be found)
-BASE_DIR = os.path.join(os.path.dirname(__file__), '../..')
-sys.path.append(BASE_DIR)
+# # this needs to happen before import pytetrad (otherwise lib cant be found)
+# BASE_DIR = os.path.join(os.path.dirname(__file__), '../..')
+# sys.path.append(BASE_DIR)
 
 import numpy as np
 import pandas as pd

--- a/pytetrad/tools/translate.py
+++ b/pytetrad/tools/translate.py
@@ -6,7 +6,9 @@ import jpype
 import jpype.imports
 
 import os
-jar_path = os.path.abspath("../resources/tetrad-current.jar")
+import importlib.resources as importlib_resources
+jar_path = importlib_resources.files('pytetrad').joinpath(['resources','tetrad-current.jar'])
+jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
         jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])

--- a/pytetrad/tools/translate.py
+++ b/pytetrad/tools/translate.py
@@ -7,7 +7,7 @@ import jpype.imports
 
 import os
 import importlib.resources as importlib_resources
-jar_path = importlib_resources.files('pytetrad').joinpath(['resources','tetrad-current.jar'])
+jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:

--- a/pytetrad/tools/translate.py
+++ b/pytetrad/tools/translate.py
@@ -5,10 +5,14 @@
 import jpype
 import jpype.imports
 
-try:
-    jpype.startJVM(classpath=[f"../resources/tetrad-current.jar"])
-except OSError:
-    pass
+import os
+jar_path = os.path.abspath("../resources/tetrad-current.jar")
+if not jpype.isJVMStarted():
+    try:
+        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+    except OSError:
+        print("can't load jvm")
+        pass
 
 import os
 import sys

--- a/pytetrad/tools/translate.py
+++ b/pytetrad/tools/translate.py
@@ -5,13 +5,12 @@
 import jpype
 import jpype.imports
 
-import os
 import importlib.resources as importlib_resources
 jar_path = importlib_resources.files('pytetrad').joinpath('resources','tetrad-current.jar')
 jar_path = str(jar_path)
 if not jpype.isJVMStarted():
     try:
-        jpype.startJVM(jpype.getDefaultJVMPath(), "-Xmx2g", classpath=[jar_path])
+        jpype.startJVM(jpype.getDefaultJVMPath(), classpath=[jar_path])
     except OSError:
         print("can't load jvm")
         pass

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+import setuptools
+
+with open('README.md', 'r') as fh:
+    README = fh.read()
+
+VERSION = '0.1.2'
+
+setuptools.setup(
+    name='py-tetrad',
+    version=VERSION,
+    author='Joseph Ramsey and Bryan Andrews',
+    description='py-tetrad Python Package',
+    long_description=README,
+    long_description_content_type='text/markdown',
+    install_requires=[
+        'numpy',
+        'pandas',
+        'JPype1',
+    ],
+    url='https://github.com/cmu-phil/py-tetrad',
+    packages=setuptools.find_packages(include=['pytetrad', 'pytetrad.*']),
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+    ],
+    python_requires='>=3.7',
+)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setuptools.setup(
     ],
     url='https://github.com/cmu-phil/py-tetrad',
     packages=setuptools.find_packages(include=['pytetrad', 'pytetrad.*']),
+    package_data={
+        'pytetrad': ['resources/*'], 
+    },
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
This PR makes it possible to install pytetrad into another python project, import pytetrad and use the python wrappers like TetradSearch, as well as the java modules straight from the jar. Pytetrad will "just work" and will stop complaining about paths not being found.